### PR TITLE
ClassDefence had an invalid trait

### DIFF
--- a/src/ClassDefence.php
+++ b/src/ClassDefence.php
@@ -6,6 +6,6 @@ trait ClassDefence
 {
     use Unserializable;
     use Unclonable;
-    use Uninvoke;
+    use Uninvokable;
 }
 

--- a/test/ClassDefenceTest.php
+++ b/test/ClassDefenceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace GianArb\AngryTest;
+
+use GianArb\Angry\ClassDefence;
+use PHPUnit_Framework_TestCase;
+
+class ClassDefenceTest extends PHPUnit_Framework_TestCase
+{
+    public function testClone()
+    {
+        $this->setExpectedException('DomainException');
+        $testClass = $this->getMockForTrait('GianArb\Angry\ClassDefence');
+        clone $testClass;
+    }
+
+    public function testInvoke()
+    {
+        $this->setExpectedException('DomainException');
+        $testClass = $this->getMockForTrait('GianArb\Angry\ClassDefence');
+        $testClass();
+    }
+
+    public function testSerialize()
+    {
+        $this->setExpectedException('DomainException');
+        $testClass = $this->getMockForTrait('GianArb\Angry\ClassDefence');
+        serialize($testClass);
+    }
+}


### PR DESCRIPTION
I'll be using this in https://github.com/API-Skeletons/zf-oauth2-doctrine-permissions-acl when it works.